### PR TITLE
WSL上で実行した際のクリップボードへのコピー対応

### DIFF
--- a/modules/copy_text.js
+++ b/modules/copy_text.js
@@ -6,6 +6,13 @@ module.exports = (text, osName) => {
         proc.stdin.write(text);
         proc.stdin.end();
     }
+    
+    // Linux
+    if (osName === 'linux') {
+        const proc = require('child_process').spawn('clip.exe');
+        proc.stdin.write(text);
+        proc.stdin.end();
+    }
 
     // Mac
     if (osName === 'darwin') {


### PR DESCRIPTION
# やったこと

WSLでホストした場合、クリップボードへのコピーが行われない。
そこでWSL(OS判定で `Linux` だった場合) `clip.exe` を叩くことでコピーを行う処理を追加した。

# 問題点

Native Linuxを利用する場合、このままでは動作しない。
もしその場合は、コピーコマンドなりにaliasを貼って共通にするしか無い。
しかし、本ツールの利用者層としてはNative LinuxよりもWindowsからなにかしらのnode.js環境を構築(WSLを利用)する場合が多いと考えられます。
そのため、現状では効果的な修正だと考えています。

# 開発環境&動作確認

WSL on Ubuntu

```
$  grep -H "" /etc/*version
/etc/debian_version:buster/sid
/etc/ec2_version:Ubuntu 18.04.2 LTS (Bionic Beaver)
```

node v11.9.0
```
$ node -v
v11.9.0
```

また、知人の別環境(WSL&node v10.4.0)でも動作を確認