### PR TITLE
fix typo

### DIFF
--- a/generate_bearer.js
+++ b/generate_bearer.js
@@ -6,5 +6,5 @@ const consumerKey = require('./config/consumer_key.js');
  * consumer_key, consumer_secret から アプリケーション認証に必要なbearerトークンを取得する
  */
 
-const bearerTocken = execSync(`curl -u '${consumerKey.userOuth.consumer_key}:${consumerKey.userOuth.consumer_secret}' --data 'grant_type=client_credentials' 'https://api.twitter.com/oauth2/token'`).toString();
+const bearerTocken = execSync(`curl -u '${consumerKey.userAuth.consumer_key}:${consumerKey.userAuth.consumer_secret}' --data 'grant_type=client_credentials' 'https://api.twitter.com/oauth2/token'`).toString();
 console.log(bearerTocken);


### PR DESCRIPTION
# 対応

`generate_bearer.js` のtypo修正